### PR TITLE
Add NZ_VOEC to deemed reseller categories in OrderItem

### DIFF
--- a/lib/Model/OrdersV0/OrderItem.php
+++ b/lib/Model/OrdersV0/OrderItem.php
@@ -333,7 +333,7 @@ class OrderItem implements ModelInterface, ArrayAccess, \JsonSerializable, \Iter
     const DEEMED_RESELLER_CATEGORY_NO_VOEC = 'NO_VOEC';
     const DEEMED_RESELLER_CATEGORY_CA_MPF = 'CA_MPF';
     const DEEMED_RESELLER_CATEGORY_AU_VOEC = 'AU_VOEC';
-    
+    const DEEMED_RESELLER_CATEGORY_NZ_VOEC = 'NZ_VOEC';
     
 
     /**
@@ -350,6 +350,7 @@ class OrderItem implements ModelInterface, ArrayAccess, \JsonSerializable, \Iter
             self::DEEMED_RESELLER_CATEGORY_NO_VOEC,
             self::DEEMED_RESELLER_CATEGORY_CA_MPF,
             self::DEEMED_RESELLER_CATEGORY_AU_VOEC,
+            self::DEEMED_RESELLER_CATEGORY_NZ_VOEC,
         ];
     }
     


### PR DESCRIPTION
As per https://github.com/amzn/selling-partner-api-docs/issues/2473 the type `NZ_VOEC` for deemed reseller categories in `OrderItem.php` has been recognized for being absent in the amazon documentation but used in production.